### PR TITLE
Remove setuptools from the requirements list.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
     namespace_packages=[],
     zip_safe=False,
     install_requires=[
-        'setuptools',
         # -*- Extra requirements: -*-
         'gitchangelog',
     ],


### PR DESCRIPTION
The requirement is a bit pointless as the setup.py file cannot even be executed and be parsed to find out setuptools is required if setuptools isn't found. This also is seeming to cause this package to break when installing from PyPi.
