### PR TITLE
Use try, except instead of checking __dict__.

### DIFF
--- a/colour.py
+++ b/colour.py
@@ -938,9 +938,10 @@ class Color(object):
             setattr(self, k, v)
 
     def __getattr__(self, label):
-        if ('get_' + label) in self.__class__.__dict__:
+        try:
             return getattr(self, 'get_' + label)()
-        raise AttributeError("'%s' not found" % label)
+        except AttributeError:
+            raise AttributeError("'%s' not found" % label)
 
     def __setattr__(self, label, value):
         if label not in ["_hsl", "equality"]:


### PR DESCRIPTION
This allows you to create subclasses of colour.Color, since `__dict__` is not
inherited by subclasses.