### PR TITLE
Added invert attribute, fixes #17

### DIFF
--- a/colour.py
+++ b/colour.py
@@ -1136,6 +1136,31 @@ class Color(object):
         for hsl in color_scale(self._hsl, Color(value).hsl, steps - 1):
             yield Color(hsl=hsl)
 
+    def invert(self, label):
+        # If compound label, replace with list of simple labels
+        # If not, convert to list
+        # New color systems should be added here to avoid a ValueError
+        if label in ['rgb', 'hex']:
+            label = ['red', 'green', 'blue']
+        elif label in ['hsl']:
+            label = ['hue', 'saturation', 'luminance']
+        else:
+            label = [label]
+        
+        # For each label in list, check type then invert
+        # New attributes should be added here to avoid a ValueError
+        circular = ['hue']
+        linear = ['saturation', 'luminance', 'red', 'green', 'blue']
+        for a in label:
+            if a in circular:
+                value = (getattr(self, a) + 0.5) % 1
+            elif a in linear:
+                value = (1 - getattr(self, a))
+            else:
+                raise ValueError("Unknown how to invert attribute: %s"
+                                 % a)
+            setattr(self, a, value)
+
     ##
     ## Convenience
     ##

--- a/colour.py
+++ b/colour.py
@@ -1138,7 +1138,7 @@ class Color(object):
 
     def invert(self, label):
         compound = {'rgb': ['red', 'green', 'blue'],
-                    'hex': ['red', 'green', 'blue']
+                    'hex': ['red', 'green', 'blue'],
                     'hsl': ['hue', 'saturation', 'luminance']
                     }
         circular = ['hue']

--- a/colour.py
+++ b/colour.py
@@ -1137,20 +1137,23 @@ class Color(object):
             yield Color(hsl=hsl)
 
     def invert(self, label):
+        compound = {'rgb': ['red', 'green', 'blue'],
+                    'hex': ['red', 'green', 'blue']
+                    'hsl': ['hue', 'saturation', 'luminance']
+                    }
+        circular = ['hue']
+        linear = ['saturation', 'luminance', 'red', 'green', 'blue']
+        
         # If compound label, replace with list of simple labels
         # If not, convert to list
-        # New color systems should be added here to avoid a ValueError
-        if label in ['rgb', 'hex']:
-            label = ['red', 'green', 'blue']
-        elif label in ['hsl']:
-            label = ['hue', 'saturation', 'luminance']
+        # New color systems should be added to compound dictionary to avoid a ValueError
+        if label in compound:
+            label = compound[label]
         else:
             label = [label]
         
-        # For each label in list, check type then invert
+        # For each label in list, check type (circular/linear) then invert
         # New attributes should be added here to avoid a ValueError
-        circular = ['hue']
-        linear = ['saturation', 'luminance', 'red', 'green', 'blue']
         for a in label:
             if a in circular:
                 value = (getattr(self, a) + 0.5) % 1


### PR DESCRIPTION
Added  `invert` attribute to the `Color` class. All current colour atributes are supported (I think). Hue is rotated x+0.5, all other attributes are 1-x type inversion.

Takes one argument (the attribute to invert), toabi I agree it's a bit more complex but I'd prefer to be at least able to choose hue, rgb or hsl to invert, if not every attribute.

Usage:

```
c = Color('orange')
c.invert('rgb')
c.invert('hsl')
c.invert('hex') # Inverts using rgb
c.invert('red') # etc. etc.
```

New attribute inversions can be supported by adding to the dictionary/lists just after attribute declaration. If attribute not recognised, ValueError will be raised.

Also wanted to say thanks vaab for a great module!
