### PR TITLE
fix: unexpected behavior with ``!=`` operator. (fixes #26)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,6 +296,8 @@ But on another non-Colour object::
 
     >>> red == None
     False
+    >>> red != None
+    True
 
 Actually, ``Colour`` instances will, politely enough, leave
 the other side of the equality have a chance to decide of the output,
@@ -312,6 +314,18 @@ the other side of the equality have a chance to decide of the output,
     True
     >>> blue == alien_red
     False
+
+And inequality (using ``__ne__``) are also polite::
+
+    >>> class AnotherColorImplem(OtherColorImplem):
+    ...     def __ne__(self, other):
+    ...         return self.color != other.web
+
+    >>> new_alien_red = AnotherColorImplem("red")
+    >>> red != new_alien_red
+    False
+    >>> blue != new_alien_red
+    True
 
 
 Picking arbitrary color for a python object

--- a/colour.py
+++ b/colour.py
@@ -38,6 +38,8 @@ from __future__ import with_statement, print_function
 
 import hashlib
 import re
+import sys
+
 
 ##
 ## Some Constants
@@ -931,6 +933,12 @@ class Color(object):
 
         >>> Color('red') == Color('blue')
         False
+        >>> Color('red') == Color('red')
+        True
+        >>> Color('red') != Color('blue')
+        True
+        >>> Color('red') != Color('red')
+        False
 
     But this can be changed:
 
@@ -1090,6 +1098,12 @@ class Color(object):
         if isinstance(other, Color):
             return self.equality(self, other)
         return NotImplemented
+
+    if sys.version_info[0] == 2:
+        ## Note: intended to be a backport of python 3 behavior
+        def __ne__(self, other):
+            equal = self.__eq__(other)
+            return equal if equal is NotImplemented else not equal
 
 
 RGB_equivalence = lambda c1, c2: c1.hex_l == c2.hex_l


### PR DESCRIPTION
This is a proposal fix for #26, in an attempt to superseed #28  in being more up to the point and avoid reimplementation and try to be future proof and pythonic : it intends of implementing actual python 3 behavior.