### PR TITLE
fixed problem in range_to when hue should've cycled.

### DIFF
--- a/colour.py
+++ b/colour.py
@@ -742,7 +742,7 @@ def color_scale(begin_hsl, end_hsl, nb):
     else:
         step_s = 0.0
     cs = [(begin_h, begin_s, begin_l)]
-    for i in range(1, nb):
+    for i in range(1, nb + 1):
         new_h = cs[-1][0] + step_h
         if new_h > 1.0:
             new_h -= 1.0

--- a/colour.py
+++ b/colour.py
@@ -742,11 +742,12 @@ def color_scale(begin_hsl, end_hsl, nb):
     else:
         step_s = 0.0
     cs = [(begin_h, begin_s, begin_l)]
-    for i in range(1, nb + 1):
+    for i in range(1, nb):
         new_h = cs[-1][0] + step_h
         if new_h > 1.0:
             new_h -= 1.0
         cs.append((new_h, cs[-1][1] + step_s, cs[-1][2] + step_l))
+    cs.append(end_hsl)
     return cs
 
 ##

--- a/colour.py
+++ b/colour.py
@@ -717,18 +717,37 @@ def color_scale(begin_hsl, end_hsl, nb):
     if nb < 0:
         raise ValueError(
             "Unsupported negative number of colors (nb=%r)." % nb)
-
-    step = tuple([float(end_hsl[i] - begin_hsl[i]) / nb for i in range(0, 3)]) \
-           if nb > 0 else (0, 0, 0)
-
-    def mul(step, value):
-        return tuple([v * value for v in step])
-
-    def add_v(step, step2):
-        return tuple([v + step2[i] for i, v in enumerate(step)])
-
-    return [add_v(begin_hsl, mul(step, r)) for r in range(0, nb + 1)]
-
+    end_h = end_hsl[0]
+    begin_h = begin_hsl[0]
+    end_s = end_hsl[1]
+    begin_s = begin_hsl[1]
+    end_l = end_hsl[2]
+    begin_l = begin_hsl[2]
+    # if distance through 1 is shorter than distance between, then we want to
+    # cycle through 1.0 instead of going all the way through all hues to get
+    # back to the color we want
+    if abs(end_h - begin_h) > abs((1.0 - begin_h) + end_h):
+        step_h = abs((1.0 - begin_h) + end_h) / nb
+    else:
+        if end_h != begin_h:
+            step_h = (end_h - begin_h) / nb
+        else:
+            step_h = 0.0
+    if end_l != begin_l:
+        step_l = (end_l - begin_l) / nb
+    else:
+        step_l = 0.0
+    if end_s != begin_s:
+        step_s = (end_s - begin_s) / nb
+    else:
+        step_s = 0.0
+    cs = [(begin_h, begin_s, begin_l)]
+    for i in range(1, nb):
+        new_h = cs[-1][0] + step_h
+        if new_h > 1.0:
+            new_h -= 1.0
+        cs.append((new_h, cs[-1][1] + step_s, cs[-1][2] + step_l))
+    return cs
 
 ##
 ## Color Pickers

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
-name = %%name%%
-version = %%version%%
-summary = %%description%%
+name = colour
+version = 0.1.5
+summary = converts and manipulates various color representation (HSL, RVB, web, X11, ...)
 description-file =
     README.rst
     CHANGELOG.rst
@@ -10,9 +10,9 @@ license_file = LICENSE
 requires-dist =
 
 ## sdist info
-author = %%author%%
-author_email = %%email%%
-home_page = http://github.com/vaab/%%name%%
+author = Valentin LAB
+author_email = valentin.lab@kalysto.org
+home_page = http://github.com/vaab/colour
 license = BSD 3-Clause License
 classifier =
     Programming Language :: Python
@@ -30,7 +30,7 @@ classifier =
 
 
 [files]
-modules = %%name%%
+modules = colour
 extra_files =
     README.rst
     CHANGELOG.rst

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except ImportError:
 ## Ensure that ``./autogen.sh`` is run prior to using ``setup.py``
 ##
 
-if "%%short-version%%".startswith("%%"):
+if "0.1.5".startswith("%%"):
     import os.path
     import sys
     WIN32 = sys.platform == 'win32'


### PR DESCRIPTION
Previously, when performing `range_to` on colors with hues that crossed `1.0`, the `color_scale` function used in `range_to` would go through all intervening hues instead of crossing `1.0`.  For example, when going from purple with hue `0.94` to red with hue `0.04`, `range_to` returned almost all colors (blue, green, yellow) by ranging from `0.94` downward to `0.04` instead of going from `0.94` to `1.0` and then restarting at `0.0` and going to `0.4`.  This commit fixes that.