### PR TITLE
Add colour preview method

### DIFF
--- a/colour.py
+++ b/colour.py
@@ -1094,6 +1094,13 @@ class Color(object):
     ##
 
     def preview(self, geometry=(200, 200)):
+        if len(geometry) != 2:
+            raise ValueError("Geometry must have a length of 2")
+
+        for i in geometry:
+            if not isinstance(i, int):
+                raise TypeError("Geometry must be a collection of integers")
+
         root = tkinter.Tk()
 
         root.geometry(f"{geometry[0]}x{geometry[1]}")

--- a/colour.py
+++ b/colour.py
@@ -34,12 +34,12 @@ Please see the documentation of this object for more information.
 
 """
 
-from __future__ import with_statement, print_function
+from __future__ import print_function, with_statement
 
 import hashlib
 import re
 import sys
-
+import tkinter
 
 ##
 ## Some Constants

--- a/colour.py
+++ b/colour.py
@@ -1093,8 +1093,14 @@ class Color(object):
     ## Convenience
     ##
 
-    def preview(self, geometry=(100, 100)):
-        pass
+    def preview(self, geometry=(200, 200)):
+        root = tkinter.Tk()
+
+        root.geometry(f"{geometry[0]}x{geometry[1]}")
+        root.config(background=self.get_hex_l())
+        root.title("Colour preview")
+
+        root.mainloop()
 
     ##
     ## Dunder

--- a/colour.py
+++ b/colour.py
@@ -1093,6 +1093,13 @@ class Color(object):
     ## Convenience
     ##
 
+    def preview(self, geometry=(100, 100)):
+        pass
+
+    ##
+    ## Dunder
+    ##
+
     def __str__(self):
         return "%s" % self.web
 


### PR DESCRIPTION
# Colour previews
Allows users to easily preview a colour using the `Color.preview()` method.

## What changed?
A new `preview` method was added to the `Color` class, allowing for quick and easy colour previews.

## How does it work?
The preview method uses Tkinter, which is included in every Python installation, and should be consistent across operating systems.
The method creates a root window, sets its geometry, sets its title and sets the background colour to whatever colour is stored in this `Color` class.

## Why?
I was recently browsing old projects of mine, and I stumbled across a list of `Color` objects. Wanting to view those colours, I searched for a quick and easy way to preview colours in Python.
After failing miserably, I took it upon myself to implement a preview method for the `Color` class.
Also, why would anyone want to implement an *essential* feature all by themselves?

## Examples
```py
>>> import colour
>>>
>>> c = colour.Color("#9F1231")
>>> c.preview() # Preview a single colour
>>>
>>> for i in c.range_to(colour.Color("#000"), 8):
...     i.preview(geometry=(200, 100)) # Preview a colour with custom geometry
... 
```