### PR TITLE
Remove unmaintained d2to1 during setup.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,20 +1,16 @@
 [metadata]
 name = %%name%%
 version = %%version%%
-summary = %%description%%
-description-file =
-    README.rst
-    CHANGELOG.rst
-    TODO.rst
-license_file = LICENSE
-requires-dist =
+description = %%description%%
+long_description = file: README.rst, CHANGELOG.rst, TODO.rst
+license_files = LICENSE
 
 ## sdist info
 author = %%author%%
 author_email = %%email%%
-home_page = http://github.com/vaab/%%name%%
+url = http://github.com/vaab/%%name%%
 license = BSD 3-Clause License
-classifier =
+classifiers =
     Programming Language :: Python
     Topic :: Software Development :: Libraries :: Python Modules
     Development Status :: 3 - Alpha
@@ -29,19 +25,10 @@ classifier =
     Programming Language :: Python :: 3.6
 
 
-[files]
-modules = %%name%%
-extra_files =
-    README.rst
-    CHANGELOG.rst
-    TODO.rst
-    setup.py
-
-
-[backwards_compat]
+[options]
 ## without this ``pip uninstall`` fails on recent version of setuptools
 ## (tested failing with setuptools 34.3.3, working with setuptools 9.1)
-zip-safe = False
+zip_safe = False
 
 
 [bdist_wheel]

--- a/setup.py
+++ b/setup.py
@@ -54,12 +54,4 @@ if "%%short-version%%".startswith("%%"):
     sys.exit(errlvl)
 
 
-##
-## Normal d2to1 setup
-##
-
-setup(
-    setup_requires=['d2to1'],
-    extras_require={'test': ['nose', ]},
-    d2to1=True
-)
+setup(extras_require={'test': ['nose', ]})


### PR DESCRIPTION
I am updating setuptools in [nixpkgs](https://github.com/NixOS/nixpkgs) to v68 and found that `d2to1` does not work anymore.

Closes https://github.com/vaab/colour/issues/60.